### PR TITLE
TST: add github test action

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,67 @@
+name: Test
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ ubuntu-latest, macOS-latest, windows-latest ]
+        python-version: [ 3.8 ]
+        tasks: [ tests ]
+        include:
+          - os: ubuntu-latest
+            python-version: 3.7
+            tasks: tests
+          - os: ubuntu-latest
+            python-version: 3.9
+            tasks: tests
+          - os: ubuntu-latest
+            python-version: 3.8
+            tasks: docs
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Install package
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt
+
+    - name: Install tests requirements
+      run: pip install -r tests/requirements.txt
+      if: matrix.tasks == 'tests'
+
+    - name: Test with pytest
+      run: python -m pytest
+      if: matrix.tasks == 'tests'
+
+    - name: Upload coverage to Codecov
+      uses: codecov/codecov-action@v1
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
+        file: ./coverage.xml
+      if: matrix.tasks == 'tests' && matrix.os == 'ubuntu-latest'
+
+    - name: Install docs requirements
+      run: pip install -r docs/requirements.txt
+      if: matrix.tasks == 'docs'
+
+    - name: Test building documentation
+      run: python -m sphinx docs/ docs/_build/ -b html -W
+      if: matrix.tasks == 'docs'
+
+    - name: Check links in documentation
+      run: python -m sphinx docs/ docs/_build/ -b linkcheck -W
+      if: matrix.tasks == 'docs'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,6 +34,12 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
 
+    - name: Ubuntu - install libsndfile
+      run: |
+        sudo apt-get update
+        sudo apt-get install --no-install-recommends --yes libsndfile1
+      if: matrix.os == 'ubuntu-latest'
+
     - name: Install package
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,12 +34,6 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
 
-    - name: Ubuntu - install libsndfile
-      run: |
-        sudo apt-get update
-        sudo apt-get install --no-install-recommends --yes libsndfile1
-      if: matrix.os == 'ubuntu-latest'
-
     - name: Install package
       run: |
         python -m pip install --upgrade pip

--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,7 @@ build/
 dist/
 .idea/
 venv/
-.coverage
+coverage.xml
 docs/pics/*.svg
 docs/.ipynb_checkpoints
 docs/examples/output

--- a/setup.cfg
+++ b/setup.cfg
@@ -42,6 +42,7 @@ addopts =
     --doctest-plus
     --cov=audpsychometric
     --cov-fail-under=100
+    --cov-report xml
     --cov-report term-missing
     --ignore=test_audeering_internal.py
     -k "not internal"

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,6 +20,7 @@ classifiers =
     Programming Language :: Python
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
     Topic :: Scientific/Engineering
 
 [options]

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,5 +1,5 @@
 # Only needed for internal test
-audb
+# audb
 # To avoid https://github.com/tholo/pytest-flake8/issues/87
 flake8 <5.0.0
 pytest

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,6 +1,5 @@
-# Only needed for internal test,
-# disable for now
-# audb
+# Only needed for internal test
+audb
 # To avoid https://github.com/tholo/pytest-flake8/issues/87
 flake8 <5.0.0
 pytest

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,4 +1,8 @@
-audb
+# Only needed for internal test,
+# disable for now
+# audb
+# To avoid https://github.com/tholo/pytest-flake8/issues/87
+flake8 <5.0.0
 pytest
 pytest-flake8
 pytest-doctestplus

--- a/tests/test_audeering_internal.py
+++ b/tests/test_audeering_internal.py
@@ -13,7 +13,6 @@ import pandas as pd
 import pingouin as pg
 import pytest
 
-import audb
 import audmetric
 import audpsychometric
 
@@ -32,7 +31,9 @@ def generate_coreset_df(coreset_name="set133"):
 
     Returns:
         table containing the ratings in wide format
+
     """
+    import audb
 
     database_name = "projectsmile-salamander-agent-tone"
     db = audb.load(database_name, only_metadata=True)


### PR DESCRIPTION
This adds a definition file for executing tests on github (so called github Actions).
It updates the `pytest` settings in `setup.cfg` to store the coverage report as a XML file, that is then uploaded in the Action to  codecov.io which we can then use in other pull request to report if the code coverage has changed.
It also limits the installed `flake8` version as the newly released 5.0.0 version does no longer work with the current latest `pytest` version.

Tests are added for:
* Ubuntu, Python 3.7, 3.8, 3.9
* Windows, Python 3.8
* MacOS, Python 3.8
* Ubuntu and building docs, Python 3.8