### PR TITLE
CI: add action to publish Python package for tag

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,73 @@
+name: Publish
+
+on:
+  push:
+    tags:
+      - 'v*' # Push events to matching v*, i.e. v1.0, v20.15.10
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 2
+
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.8'
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install setuptools wheel twine
+
+    # PyPI package
+    - name: Build and publish
+      env:
+        TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
+        TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
+      run: |
+        python setup.py sdist bdist_wheel
+        python -m twine upload dist/*
+
+    # Docuemntation
+    - name: Install doc dependencies
+      run: |
+        pip install -r requirements.txt
+        pip install -r docs/requirements.txt
+
+    - name: Build documentation
+      run: |
+        python -m sphinx docs/ docs/_build/ -b html
+
+    - name: Deploy documentation to Github pages
+      uses: peaceiris/actions-gh-pages@v3
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        publish_dir: ./docs/_build
+
+    # Github release
+    - name: Read CHANGELOG
+      id: changelog
+      run: |
+        # Get bullet points from last CHANGELOG entry
+        CHANGELOG=$(git diff -U0 HEAD^ HEAD | grep '^[+][\* ]' | sed 's/\+//')
+        # Support for multiline, see
+        # https://github.com/actions/create-release/pull/11#issuecomment-640071918
+        CHANGELOG="${CHANGELOG//'%'/'%25'}"
+        CHANGELOG="${CHANGELOG//$'\n'/'%0A'}"
+        CHANGELOG="${CHANGELOG//$'\r'/'%0D'}"
+        echo "Got changelog: $CHANGELOG"
+        echo "::set-output name=body::$CHANGELOG"
+
+    - name: Create release on Github
+      id: create_release
+      uses: actions/create-release@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        tag_name: ${{ github.ref }}
+        release_name: Release ${{ github.ref }}
+        body: ${{ steps.changelog.outputs.body }}


### PR DESCRIPTION
This adds a action to do the following steps when pushing a tag to the repo:

* Publishes a Python package at pypi.org using credentials (secrets) stored in the `audeering` group settings
* Build documentation and push them to the `gh-pages` branch, which we can setup to get published as github pages after the first execution. This will then host the documentation under https://audeering.github.io/audpsychometric/, compare https://audeering.github.io/audb/
* Create a github release entry from the text that was added to the `CHANGELOG.rst` file with the commit corresponding to the tag. A github release entry looks like thos: https://github.com/audeering/audb/releases/tag/v1.3.0