### PR TITLE
DOC: require sphinx-audeering-theme>=1.2.1

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -76,5 +76,4 @@ intersphinx_mapping = {
     'scipy': ('http://docs.scipy.org/doc/scipy/reference/', None),
     'seaborn': ('https://seaborn.pydata.org/', None),
     'sklearn': ('http://scikit-learn.org/stable', None),
-    'statsmodels': ('http://www.statsmodels.org/stable/', None),
 }

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,6 +1,6 @@
 jupyter-sphinx
 sphinx
-sphinx-audeering-theme >=0.8.0
+sphinx-audeering-theme >=1.2.1
 sphinx-autodoc-typehints
 sphinx-copybutton
 sphinxcontrib-programoutput

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,9 +31,8 @@ install_requires =
     pingouin
     numpy
     pandas
+    scikit-learn
     statsmodels
-    sklearn
-
 setup_requires =
     setuptools_scm
 


### PR DESCRIPTION
In order to avoid installing `sphinx>5` we need to enforce the latest `sphinx-audeering-theme` version.