### PR TITLE
Remove support for Python 3.7

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,9 +2,9 @@ name: Test
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
 
 jobs:
   build:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,9 +17,6 @@ jobs:
         tasks: [ tests ]
         include:
           - os: ubuntu-latest
-            python-version: 3.7
-            tasks: tests
-          - os: ubuntu-latest
             python-version: 3.9
             tasks: tests
           - os: ubuntu-latest

--- a/audpsychometric/core/reliability.py
+++ b/audpsychometric/core/reliability.py
@@ -348,12 +348,12 @@ def intra_class_correlation(df: pd.DataFrame,
 
     anova_table = _anova(data_long, anova_method=anova_method)
 
-    bms = anova_table["mean_sq"][0]
-    wms = (anova_table["sum_sq"][1] + anova_table["sum_sq"][2]) / (
-        anova_table["df"][1] + anova_table["df"][2]
+    bms = anova_table["mean_sq"].iloc[0]
+    wms = (anova_table["sum_sq"].iloc[1] + anova_table["sum_sq"].iloc[2]) / (
+        anova_table["df"].iloc[1] + anova_table["df"].iloc[2]
     )
-    jms = anova_table["mean_sq"][1]
-    ems = anova_table["mean_sq"][2]
+    jms = anova_table["mean_sq"].iloc[1]
+    ems = anova_table["mean_sq"].iloc[2]
 
     k = data_long["rater"].nunique()
     n = data_long["item"].nunique()

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,4 @@
+ipykernel
 jupyter-sphinx
 sphinx
 sphinx-audeering-theme >=1.2.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -38,7 +38,6 @@ setup_requires =
 
 [tool:pytest]
 addopts =
-    --flake8
     --doctest-plus
     --cov=audpsychometric
     --cov-fail-under=100

--- a/setup.cfg
+++ b/setup.cfg
@@ -18,7 +18,6 @@ classifiers =
     License :: audEERING
     Operating System :: OS Independent
     Programming Language :: Python
-    Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Topic :: Scientific/Engineering

--- a/tests/test_gold_standard.py
+++ b/tests/test_gold_standard.py
@@ -32,7 +32,7 @@ def test_mode_based_gold_standard():
     assert isinstance(df, pd.DataFrame)
     assert "gold_standard" in df.columns
     assert "confidence" in df.columns
-    assert np.alltrue((df['confidence'] >= 0.) & (df['confidence'] <= 1.).values)
+    assert np.all((df['confidence'] >= 0.) & (df['confidence'] <= 1.).values)
 
 
 # The expected confidence value for this test


### PR DESCRIPTION
Remove support for Python 3.7 and ensure tests work again by removing `flake8` pytest plugin.

The package will be changed to use `ruff` in an upcoming pull request.