### PR TITLE
DOC: use sphinx-apipages plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ dist/
 .idea/
 venv/
 coverage.xml
+docs/api/
 docs/pics/*.svg
 docs/.ipynb_checkpoints
 docs/examples/output

--- a/audpsychometric/__init__.py
+++ b/audpsychometric/__init__.py
@@ -1,20 +1,3 @@
-"""Library to facilitate evaluation and processing of annotated speech.
-
-The input data format for all functions in this module is the same:
-a :class:`pd.DataFrame` is expected.
-
-This dataframe is assumed to
-
-- have an index that identifies the unit of observation,
-  e.g. a psychometric item to be rated
-- have a separate column for each rater
-
-So the entry in the frame at (irow, icol)
-identifies the rating of unit irow by rather icol.
-Note that these assumptions are not checked
-and are under responsibility of the user.
-
-"""
 import audpsychometric.core
 from audpsychometric.core import datasets
 from audpsychometric.core.datasets import list_datasets

--- a/docs/api-src/audpsychometric.rst
+++ b/docs/api-src/audpsychometric.rst
@@ -3,8 +3,32 @@ audpsychometric
 
 .. automodule:: audpsychometric
 
+Library to facilitate evaluation and processing of annotated speech.
+
+The input data format for all functions in this module is the same:
+a :class:`pd.DataFrame` is expected.
+
+This dataframe is assumed to
+
+- have an index that identifies the unit of observation,
+  e.g. a psychometric item to be rated
+- have a separate column for each rater
+
+So the entry in the frame at (irow, icol)
+identifies the rating of unit irow by rather icol.
+Note that these assumptions are not checked
+and are under responsibility of the user.
+
 Pychometric Analysis
 --------------------
+
+.. autosummary::
+    :toctree:
+    :nosignatures:
+
+    cronbachs_alpha
+    congeneric_reliability
+    intra_class_correlation
 
 The module currently contains two reliability coefficients
 from the family of structural equation model (SEM)-based
@@ -38,53 +62,30 @@ We do not implement it here,
 as there are other implementations available,
 e.g. :func:`audmetric.concordance_cc`.
 
-cronbachs_alpha
-^^^^^^^^^^^^^^^
-
-.. autofunction:: cronbachs_alpha
-
-congeneric_reliability
-^^^^^^^^^^^^^^^^^^^^^^
-
-.. autofunction:: congeneric_reliability
-
-intra_class_correlation
-^^^^^^^^^^^^^^^^^^^^^^^
-
-.. autofunction:: intra_class_correlation
-
 
 Gold Standard Calculation
 -------------------------
 
-evaluator_weighted_estimator
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+.. autosummary::
+    :toctree:
+    :nosignatures:
 
-.. autofunction:: evaluator_weighted_estimator
-
-gold_standard_mean
-^^^^^^^^^^^^^^^^^^
-
-.. autofunction:: gold_standard_mean
-
-gold_standard_median
-^^^^^^^^^^^^^^^^^^^^
-
-.. autofunction:: gold_standard_median
-
-gold_standard_mode
-^^^^^^^^^^^^^^^^^^
-
-.. autofunction:: gold_standard_mode
-
-rater_confidence_pearson
-^^^^^^^^^^^^^^^^^^^^^^^^
-
-.. autofunction:: rater_confidence_pearson
+    evaluator_weighted_estimator
+    gold_standard_mean
+    gold_standard_median
+    gold_standard_mode
+    rater_confidence_pearson
 
 
 Demo Datasets
 -------------
+
+.. autosummary::
+    :toctree:
+    :nosignatures:
+
+    list_datasets
+    read_dataset
 
 Currently these datasets are defined:
 
@@ -93,16 +94,6 @@ Currently these datasets are defined:
     from audpsychometric import datasets
     df_datasets = datasets.list_datasets()
     print(df_datasets)
-
-list_datasets
-^^^^^^^^^^^^^
-
-.. autofunction:: list_datasets
-
-read_dataset
-^^^^^^^^^^^^
-
-.. autofunction:: read_dataset
 
 
 .. _one-dimensional congeneric reliability: https://en.wikipedia.org/wiki/Congeneric_reliability

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -17,7 +17,13 @@ title = "Documentation"
 master_doc = "index"
 extensions = []
 source_suffix = ".rst"
-exclude_patterns = ["_build", "Thumbs.db", ".DS_Store", "**.ipynb_checkpoints"]
+exclude_patterns = [
+    "api-src",
+    "build",
+    "Thumbs.db",
+    ".DS_Store",
+    "**.ipynb_checkpoints",
+]
 pygments_style = None
 extensions = [
     "jupyter_sphinx",  # executing code blocks
@@ -28,6 +34,7 @@ extensions = [
     "sphinx_autodoc_typehints",
     "sphinx_copybutton",  # for "copy to clipboard" buttons
     "sphinxcontrib.bibtex",
+    "sphinx_apipages",
 ]
 
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -14,7 +14,7 @@
     :caption: API Documentation
     :hidden:
 
-    api
+    api/audpsychometric
     genindex
     bibliography
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -2,6 +2,7 @@ audeer
 ipykernel
 jupyter-sphinx
 sphinx
+sphinx-apipages >=0.1.2
 sphinx-audeering-theme >=1.2.1
 sphinx-autodoc-typehints
 sphinx-copybutton


### PR DESCRIPTION
Switch documentation to use [sphinx-apipages](https://github.com/audeering/sphinx-apipages/) plugin for generating the API pages.

The API page has still the structure as before, and discussed the different functions:

![image](https://github.com/user-attachments/assets/cece124b-1ffe-45c2-b00b-069b7666f70a)


![image](https://github.com/user-attachments/assets/4352dca9-4c91-4283-8af2-cdc1394ca2c7)
