### PR TITLE
Rename rater_agreement_pearson() to rater_agreement()

### DIFF
--- a/audpsychometric/__init__.py
+++ b/audpsychometric/__init__.py
@@ -4,7 +4,7 @@ from audpsychometric.core.gold_standard import agreement_categorical
 from audpsychometric.core.gold_standard import agreement_numerical
 from audpsychometric.core.gold_standard import evaluator_weighted_estimator
 from audpsychometric.core.gold_standard import mode
-from audpsychometric.core.gold_standard import rater_agreement_pearson
+from audpsychometric.core.gold_standard import rater_agreement
 from audpsychometric.core.reliability import congeneric_reliability
 from audpsychometric.core.reliability import cronbachs_alpha
 from audpsychometric.core.reliability import intra_class_correlation

--- a/audpsychometric/core/gold_standard.py
+++ b/audpsychometric/core/gold_standard.py
@@ -140,7 +140,7 @@ def evaluator_weighted_estimator(
 
     """
     ratings = np.array(ratings)
-    agreements = rater_agreement_pearson(ratings, axis=axis)
+    agreements = rater_agreement(ratings, axis=axis)
     # Ensure columns represents different raters
     if axis == 0:
         ratings = ratings.T
@@ -197,7 +197,7 @@ def mode(
     )
 
 
-def rater_agreement_pearson(
+def rater_agreement(
     ratings: typing.Sequence,
     *,
     axis: int = 1,
@@ -205,7 +205,7 @@ def rater_agreement_pearson(
     """Calculate rater agreements.
 
     Calculate the agreement of a rater
-    by the correlation of a rater
+    by the Pearson correlation of a rater
     with the mean score of all other raters.
 
     This should not be confused with the agreement value
@@ -225,9 +225,9 @@ def rater_agreement_pearson(
         rater agreements
 
     Examples:
-        >>> rater_agreement_pearson([[1, 1, 0], [2, 2, 1]])
+        >>> rater_agreement([[1, 1, 0], [2, 2, 1]])
         array([1., 1., 1.])
-        >>> rater_agreement_pearson([[1, 1, 0], [2, 2, 1], [2, 2, 2]])
+        >>> rater_agreement([[1, 1, 0], [2, 2, 1], [2, 2, 2]])
         array([0.94491118, 0.94491118, 0.8660254 ])
 
     """

--- a/docs/api-src/audpsychometric.rst
+++ b/docs/api-src/audpsychometric.rst
@@ -15,5 +15,5 @@ audpsychometric
     intra_class_correlation
     list_datasets
     mode
-    rater_agreement_pearson
+    rater_agreement
     read_dataset

--- a/tests/test_gold_standard.py
+++ b/tests/test_gold_standard.py
@@ -153,7 +153,7 @@ def test_agreement_numerical(ratings, minimum, maximum, axis, expected):
         )
 
 
-def test_rater_agreement_pearson(df_holzinger_swineford):
+def test_rater_agreement(df_holzinger_swineford):
     """Test rater agreement."""
     # there is a very unrealible rater in this set with .24
     expected = np.array(
@@ -170,7 +170,7 @@ def test_rater_agreement_pearson(df_holzinger_swineford):
         ],
     )
     np.testing.assert_allclose(
-        audpsychometric.rater_agreement_pearson(df_holzinger_swineford),
+        audpsychometric.rater_agreement(df_holzinger_swineford),
         expected,
     )
 


### PR DESCRIPTION
Closes #15 

Renames `audpsychometric.rater_agreement_pearson()` to `audpsychometric.rater_agreement()`, to have the option to use another correlation measure at a later stage, e.g. by adding an `association_type` argument.

![image](https://github.com/user-attachments/assets/ab5f9137-ab4a-4523-b249-27c4d9dc5c67)
