### PR TITLE
DOC: remove obsolete changelog entries

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,36 +7,6 @@ The format is based on `Keep a Changelog`_,
 and this project adheres to `Semantic Versioning`_.
 
 
-Version 0.3.0 (2021-02-15)
---------------------------
-
-* Added: docstrings for class attributes
-* Changed: extract author and project name from ``setup.cfg``
-* Changed: use ``audeer.git_repo_version()`` to get version of docs
-* Changed: CI pipeline installs custom docker images
-* Changed: CI pipeline now uses new Artifactory tokenizer project
-
-
-Version 0.2.0 (2020-09-01)
---------------------------
-
-* Added: ``project_urls`` to :file:`setup.cfg` to store documentation URL
-* Changed: use absolute imports
-* Changed: moved project to tools
-* Changed: use ``url`` instead of ``home-page`` in :file:`setup.cfg`
-
-
-Version 0.1.1 (2020-03-20)
---------------------------
-
-* Added: :mod:`audpsychometric.define`
-
-
-Version 0.1.0 (2020-03-02)
---------------------------
-
-* Added: initial release
-
 
 .. _Keep a Changelog:
     https://keepachangelog.com/en/1.0.0/


### PR DESCRIPTION
The changelog contained entries for versions `0.1.0`, `0.1.1`, `0.2.0`, `0.3.0`, but I couldn't find any related tags in this repository, nor any published `audpsychometric` Python package on our internal or the public PyPI server.

So, I would propose to simply delete all entries, and start with version `0.1.0` when creating the first release.