### PR TITLE
Remove requirements-dev.txt

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,0 @@
-yapf
-isort
-docformatter
-jedi
-autopep8
-pre-commit


### PR DESCRIPTION
With https://github.com/audeering/audpsychometric/pull/11 we no longer need the `requirements-dev.txt` file, which is removed in this pull request.