### PR TITLE
DOC: remove links to internal Gitlab server

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -70,6 +70,10 @@ html_theme = "sphinx_audeering_theme"
 html_theme_options = {
     "display_version": True,
     "logo_only": False,
+    "footer_links": False,
+}
+html_context = {
+    "display_github": True,
 }
 html_title = title
 


### PR DESCRIPTION
Closes #22.

The top of the documentation now looks like this:

![image](https://github.com/user-attachments/assets/47d8d212-cb8f-42f3-9519-1b39dfa1fa6f)

And the footer is changed to

![image](https://github.com/user-attachments/assets/6c6ea4fd-2a30-4639-b87b-c7d4be8fe097)
