### PR TITLE
Remove typing module

### DIFF
--- a/audpsychometric/core/datasets/__init__.py
+++ b/audpsychometric/core/datasets/__init__.py
@@ -40,11 +40,11 @@ def read_dataset(data_set_name: str) -> pd.DataFrame:
     return df
 
 
-def list_datasets():
-    r"""List tests datasets available in package.
+def list_datasets() -> pd.DataFrame:
+    """List datasets available in package.
 
     Returns:
-        dataframe listing available datasets
+        dataframe listing available datasets.
 
     Examples:
         >>> list_datasets()

--- a/audpsychometric/core/datasets/__init__.py
+++ b/audpsychometric/core/datasets/__init__.py
@@ -44,7 +44,7 @@ def list_datasets() -> pd.DataFrame:
     """List datasets available in package.
 
     Returns:
-        dataframe listing available datasets.
+        dataframe listing available datasets
 
     Examples:
         >>> list_datasets()

--- a/audpsychometric/core/gold_standard.py
+++ b/audpsychometric/core/gold_standard.py
@@ -1,4 +1,8 @@
-import typing
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from collections.abc import Sequence
 
 import numpy as np
 import pandas as pd
@@ -7,10 +11,10 @@ import audmetric
 
 
 def agreement_categorical(
-    ratings: typing.Sequence,
+    ratings: Sequence,
     *,
     axis: int = 1,
-) -> typing.Union[float, np.ndarray]:
+) -> float | np.ndarray:
     r"""Confidence score for categorical ratings.
 
     The agreement for categorical data
@@ -50,12 +54,12 @@ def agreement_categorical(
 
 
 def agreement_numerical(
-    ratings: typing.Sequence,
+    ratings: Sequence,
     minimum: float,
     maximum: float,
     *,
     axis: int = 1,
-) -> typing.Union[float, np.ndarray]:
+) -> float | np.ndarray:
     r"""Confidence score for numerical ratings.
 
     .. math::
@@ -103,10 +107,10 @@ def agreement_numerical(
 
 
 def evaluator_weighted_estimator(
-    ratings: typing.Sequence,
+    ratings: Sequence,
     *,
     axis: int = 1,
-) -> typing.Union[float, np.ndarray]:
+) -> float | np.ndarray:
     r"""Evaluator weighted estimator (EWE) of raters' votes.
 
     The EWE is described in
@@ -150,10 +154,10 @@ def evaluator_weighted_estimator(
 
 
 def mode(
-    ratings: typing.Sequence,
+    ratings: Sequence,
     *,
     axis: int = 1,
-) -> typing.Any:
+) -> object:
     r"""Mode of categorical ratings.
 
     ``None`` and ``nan`` values are ignored per item.
@@ -200,7 +204,7 @@ def mode(
 
 
 def rater_agreement(
-    ratings: typing.Sequence,
+    ratings: Sequence,
     *,
     axis: int = 1,
 ) -> np.ndarray:
@@ -256,7 +260,7 @@ def rater_agreement(
     return np.array(agreements)
 
 
-def _value_or_array(values: np.ndarray) -> typing.Union[float, np.ndarray]:
+def _value_or_array(values: np.ndarray) -> float | np.ndarray:
     r"""Convert single valued arrays to value.
 
     Squeeze array,
@@ -276,7 +280,7 @@ def _value_or_array(values: np.ndarray) -> typing.Union[float, np.ndarray]:
     return values
 
 
-def _mode(ratings: np.ndarray, *, remove_nan=False) -> typing.Any:
+def _mode(ratings: np.ndarray, *, remove_nan=False) -> object:
     """Mode of categorical values.
 
     Args:

--- a/audpsychometric/core/gold_standard.py
+++ b/audpsychometric/core/gold_standard.py
@@ -1,7 +1,5 @@
-
 from __future__ import annotations
 
-from collections.abc import Callable
 from collections.abc import Sequence
 
 import numpy as np

--- a/audpsychometric/core/reliability.py
+++ b/audpsychometric/core/reliability.py
@@ -1,7 +1,5 @@
-
 from __future__ import annotations
 
-from collections.abc import Callable
 from collections.abc import Sequence
 
 import numpy as np

--- a/audpsychometric/core/reliability.py
+++ b/audpsychometric/core/reliability.py
@@ -1,4 +1,8 @@
-import typing
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from collections.abc import Sequence
 
 import numpy as np
 import pandas as pd
@@ -9,10 +13,10 @@ import statsmodels.formula.api
 
 
 def cronbachs_alpha(
-    ratings: typing.Sequence,
+    ratings: Sequence,
     *,
     axis: int = 1,
-) -> typing.Tuple[float, typing.Dict]:
+) -> tuple[float, dict]:
     r"""Calculate Cronbach's alpha.
 
     The Cronbach coefficient quantifying interrater agreement.
@@ -67,10 +71,10 @@ def cronbachs_alpha(
 
 
 def congeneric_reliability(
-    ratings: typing.Sequence,
+    ratings: Sequence,
     *,
     axis: int = 1,
-) -> typing.Tuple[float, typing.Dict]:
+) -> tuple[float, dict]:
     r"""Congeneric reliability coefficient.
 
     Extracts the first Principal Component as a measurement model
@@ -111,12 +115,12 @@ def congeneric_reliability(
 
 
 def intra_class_correlation(
-    ratings: typing.Sequence,
+    ratings: Sequence,
     *,
     axis: int = 1,
     icc_type: str = "ICC_1_1",
     anova_method: str = "pingouin",
-) -> typing.Tuple[float, typing.Dict]:
+) -> tuple[float, dict]:
     r"""Intraclass Correlation.
 
     Intraclass correlation calculates rating reliability by relating


### PR DESCRIPTION
# Purpose

While removing support for Python 3.8 elseqhere, which has reached its end-of-life, typing is refactored. While audpsychometric does not support Python 3.8, it still uses the `typing` module for type hinting which is getting uncommon with more recent python versions e.g. `list[str]` for type hinting instead of `typing.List[str]`. I also removed occurrences of `typing.Union` in favor of using `|`. `typing.Any` is becoming `object` which is the highest type in Python's type hierarchy.
